### PR TITLE
fix(ci): update GitHub Actions workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,26 +3,44 @@ name: CI
 on: [push]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-      - uses: pnpm/action-setup@v2
-      - run: pnpm install
-      - run: pnpm run lint
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run test
         env:
           CI: true
   vistest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-      - uses: pnpm/action-setup@v2
-      - run: pnpm install
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run vistest:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
@@ -19,11 +19,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
@@ -34,11 +34,11 @@ jobs:
   vistest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to improve modularity and reliability. The changes include splitting the `test` job into separate `lint` and `test` jobs, upgrading actions to specific versions, and introducing caching for `pnpm` to optimize dependency management.

### CI Workflow Improvements:

* **Job Separation**: The `test` job was split into two distinct jobs: `lint` and `test`, enhancing clarity and modularity in the workflow.
* **Action Version Upgrades**: Updated actions (`checkout`, `setup-node`, and `pnpm/action-setup`) to specific versions for improved reliability and compatibility.
* **Dependency Management Optimization**: Added `pnpm` caching and switched to `pnpm install --frozen-lockfile` to ensure consistent dependency resolution and faster builds.