### PR TITLE
refactor: migrate to signal-based inputs

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -705,4 +705,4 @@
 <!-- * * * * * * * * * * End of Placeholder * * * * * * * * * * * -->
 <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
 
-<router-outlet></router-outlet>
+<router-outlet />

--- a/src/app/recipes/alert/alert.component.ts
+++ b/src/app/recipes/alert/alert.component.ts
@@ -4,11 +4,11 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  EventEmitter,
   HostBinding,
   Input,
-  Output,
   inject,
+  input,
+  output,
 } from '@angular/core';
 
 type AlertContext = 'primary' | 'secondary' | 'danger' | 'warning' | 'success' | 'info';
@@ -16,18 +16,17 @@ type AlertContext = 'primary' | 'secondary' | 'danger' | 'warning' | 'success' |
 @Component({
   selector: 'app-alert',
   template: `
-    <ng-content></ng-content>
+    <ng-content />
     @if (dismissible) {
       <button (click)="close()" type="button" aria-label="Close">x</button>
     }
   `,
-  styles: [
-    `
-      :host {
-        display: block;
-      }
-    `,
-  ],
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
+
   host: {
     class: 'app-alert',
     '[style.display]': 'isClosed ? "none" : "block"',
@@ -41,8 +40,7 @@ export class AlertComponent {
   /**
    * @todo Not implemented
    */
-  @Input()
-  context: AlertContext = 'secondary';
+  readonly context = input<AlertContext>('secondary');
 
   @Input()
   get dismissible(): boolean {
@@ -55,8 +53,7 @@ export class AlertComponent {
   }
   private _dismissible = false;
 
-  @Output()
-  readonly closed = new EventEmitter<void>();
+  readonly closed = output<void>();
 
   @HostBinding('attr.role')
   get role() {
@@ -67,6 +64,7 @@ export class AlertComponent {
 
   close() {
     this.isClosed = true;
+    // TODO: The 'emit' function requires a mandatory void argument
     this.closed.emit();
     this.cdRef.markForCheck();
   }

--- a/src/app/recipes/button/button.component.ts
+++ b/src/app/recipes/button/button.component.ts
@@ -1,31 +1,27 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, input } from '@angular/core';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'button[app-button]',
-  template: `<ng-content></ng-content>`,
-  styles: [
-    `
-      :host {
-        display: inline-block;
-        box-sizing: border-box;
-        border-radius: 0.5rem;
-        border: 1px solid transparent;
-        padding: 1rem 1.5rem;
-      }
-      :host-context(.app-button-stroked) {
-        border: 1px solid #333;
-      }
-    `,
-  ],
-
+  template: `<ng-content />`,
+  styles: `
+    :host {
+      display: inline-block;
+      box-sizing: border-box;
+      border-radius: 0.5rem;
+      border: 1px solid transparent;
+      padding: 1rem 1.5rem;
+    }
+    :host-context(.app-button-stroked) {
+      border: 1px solid #333;
+    }
+  `,
   host: {
     class: 'app-button',
-    '[class.app-button-stroked]': "appearance === 'stroked'",
+    '[class.app-button-stroked]': "appearance() === 'stroked'",
   },
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
 })
 export class ButtonComponent {
-  @Input() appearance: 'basic' | 'stroked' = 'basic';
+  readonly appearance = input<'basic' | 'stroked'>('basic');
 }

--- a/src/app/recipes/card/card.component.ts
+++ b/src/app/recipes/card/card.component.ts
@@ -3,14 +3,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'app-card',
   templateUrl: './card.component.html',
-  styles: [
-    `
-      :host {
-        display: block;
-      }
-    `,
-  ],
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
 })
 export class CardComponent {}

--- a/src/app/recipes/colorpicker/colorpicker.component.html
+++ b/src/app/recipes/colorpicker/colorpicker.component.html
@@ -1,5 +1,5 @@
 <div role="listbox" [attr.aria-activedescendant]="selectedOptionId ?? null">
-  @for (color of colors; track color; let index = $index) {
+  @for (color of colors(); track color; let index = $index) {
     <div
       #option
       role="option"

--- a/src/app/recipes/colorpicker/colorpicker.component.ts
+++ b/src/app/recipes/colorpicker/colorpicker.component.ts
@@ -1,12 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, inject, input, output } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 
 type Color = string;
@@ -16,21 +8,18 @@ let nextUniqueId = 0;
 @Component({
   selector: 'app-colorpicker',
   templateUrl: './colorpicker.component.html',
-  styles: [
-    `
-      :host {
-        display: block;
-      }
-    `,
-  ],
+  styles: `
+    :host {
+      display: block;
+    }
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [],
 })
 export class ColorpickerComponent implements ControlValueAccessor {
   private readonly cdRef = inject(ChangeDetectorRef);
 
-  @Input()
-  colors: Color[] = [];
+  readonly colors = input<Color[]>([]);
 
   @Input()
   set value(newValue: Color | null) {
@@ -45,15 +34,14 @@ export class ColorpickerComponent implements ControlValueAccessor {
   }
   private _value: Color | null = null;
 
-  @Output()
-  valueChange = new EventEmitter<Color | null>();
+  readonly valueChange = output<Color | null>();
 
   get id(): string {
     return this._uid;
   }
 
   get selectedOptionId(): string | null {
-    const selectedColorIndex = this.colors.findIndex((color) => color === this.value);
+    const selectedColorIndex = this.colors().findIndex((color) => color === this.value);
     return selectedColorIndex < 0 ? null : this.getOptionId(selectedColorIndex);
   }
 

--- a/src/app/recipes/testing-component/4-input.spec.ts
+++ b/src/app/recipes/testing-component/4-input.spec.ts
@@ -1,13 +1,13 @@
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { screen, render } from '@testing-library/angular';
 
 @Component({
   selector: 'app-title',
-  template: ` <h1>{{ appName }}</h1> `,
+  template: ` <h1>{{ appName() }}</h1> `,
   standalone: true,
 })
 export class TitleComponent {
-  @Input() appName = '';
+  readonly appName = input('');
 }
 
 describe('TitleComponent', () => {

--- a/src/app/recipes/testing-component/5-output.spec.ts
+++ b/src/app/recipes/testing-component/5-output.spec.ts
@@ -1,21 +1,22 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { screen, render, fireEvent } from '@testing-library/angular';
 
 @Component({
   selector: 'app-toast',
   template: `
     <div>
-      <p>{{ message }}</p>
+      <p>{{ message() }}</p>
       <button (click)="close()">Close</button>
     </div>
   `,
   standalone: true,
 })
 export class ToastComponent {
-  @Input() message = '';
-  @Output() closed = new EventEmitter<void>();
+  readonly message = input('');
+  readonly closed = output<void>();
 
   close() {
+    // TODO: The 'emit' function requires a mandatory void argument
     this.closed.emit();
   }
 }

--- a/src/app/recipes/tooltip/tooltip.directive.ts
+++ b/src/app/recipes/tooltip/tooltip.directive.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentRef, Directive, HostListener, Input, ViewContainerRef, inject } from '@angular/core';
+import { Component, ComponentRef, Directive, HostListener, ViewContainerRef, inject, input } from '@angular/core';
 
 @Component({
   template: `<div class="tooltip-pane">
@@ -34,7 +34,7 @@ export class TooltipComponent {
 export class TooltipDirective {
   private readonly vcRef = inject(ViewContainerRef);
 
-  @Input('appTooltip') message = '';
+  readonly message = input('', { alias: 'appTooltip' });
 
   private tooltipInstance: ComponentRef<TooltipComponent> | null = null;
 
@@ -50,7 +50,7 @@ export class TooltipDirective {
 
   private show() {
     this.tooltipInstance = this.vcRef.createComponent(TooltipComponent);
-    this.tooltipInstance.instance.message = this.message;
+    this.tooltipInstance.instance.message = this.message();
     this.tooltipInstance.changeDetectorRef.detectChanges();
   }
 


### PR DESCRIPTION
## Summary
- Replace @Input decorators with signal inputs across components
- Update tooltip directive to use input() signal for message
- Update button, card, alert, and colorpicker components
- Update test files to work with signal inputs
- Improve type safety with signal-based component inputs

## Test plan
- [ ] Run `pnpm test` to ensure all tests pass
- [ ] Run `pnpm build` to verify production build
- [ ] Run `pnpm lint` to check code quality
- [ ] Verify components work correctly with signal inputs

🤖 Generated with [Claude Code](https://claude.ai/code)